### PR TITLE
Modified iframes properties. 

### DIFF
--- a/map.json
+++ b/map.json
@@ -501,6 +501,11 @@
                  "value":"https:\/\/app.leonardo.ai\/auth\/login"
                 }, 
                 {
+                 "name":"openWebsite",
+                 "type":"string",
+                 "value":"https:\/\/app.leonardo.ai\/auth\/login"
+                }, 
+                {
                  "name":"openWebsiteAllowApi",
                  "type":"string",
                  "value":"true"
@@ -1178,6 +1183,11 @@
          "name":"UrlTutoren",
          "opacity":1,
          "properties":[
+                {
+                 "name":"openTab",
+                 "type":"string",
+                 "value":"https:\/\/www.uni-weimar.de\/de\/universitaet\/studium\/elearning-labor\/medienbereichertes-lehren-und-lernen\/qualifizierung\/tutoreneteach\/"
+                }, 
                 {
                  "name":"openWebsite",
                  "type":"string",

--- a/map.json
+++ b/map.json
@@ -501,11 +501,6 @@
                  "value":"https:\/\/app.leonardo.ai\/auth\/login"
                 }, 
                 {
-                 "name":"openWebsite",
-                 "type":"string",
-                 "value":"https:\/\/app.leonardo.ai\/auth\/login"
-                }, 
-                {
                  "name":"openWebsiteAllowApi",
                  "type":"string",
                  "value":"true"
@@ -681,11 +676,6 @@
                  "name":"openTab",
                  "type":"string",
                  "value":"https:\/\/www.uni-weimar.de\/de\/universitaet\/studium\/elearning-labor\/medienbereichertes-lehren-und-lernen\/qualifizierung\/kursangebote\/"
-                }, 
-                {
-                 "name":"openWebsite",
-                 "type":"string",
-                 "value":"https:\/\/www.uni-weimar.de\/de\/universitaet\/studium\/elearning-labor\/medienbereichertes-lehren-und-lernen\/qualifizierung\/kursangebote\/"
                 }],
          "type":"tilelayer",
          "visible":true,
@@ -858,11 +848,6 @@
                  "name":"openTab",
                  "type":"string",
                  "value":"https:\/\/www.youtube.com\/"
-                }, 
-                {
-                 "name":"openWebsite",
-                 "type":"string",
-                 "value":"https:\/\/youtube.com"
                 }],
          "type":"tilelayer",
          "visible":true,
@@ -1028,11 +1013,6 @@
          "properties":[
                 {
                  "name":"openTab",
-                 "type":"string",
-                 "value":"https:\/\/www.uni-weimar.de\/de\/universitaet\/studium\/elearning-labor\/medienbereichertes-lehren-und-lernen\/qualifizierung\/themen-und-tools\/"
-                }, 
-                {
-                 "name":"openWebsite",
                  "type":"string",
                  "value":"https:\/\/www.uni-weimar.de\/de\/universitaet\/studium\/elearning-labor\/medienbereichertes-lehren-und-lernen\/qualifizierung\/themen-und-tools\/"
                 }],
@@ -1366,7 +1346,7 @@
          "opacity":1,
          "properties":[
                 {
-                 "name":"openWebsite",
+                 "name":"openTab",
                  "type":"string",
                  "value":"https:\/\/www.eteach-thueringen.de\/"
                 }],
@@ -1533,7 +1513,7 @@
          "opacity":1,
          "properties":[
                 {
-                 "name":"openWebsite",
+                 "name":"openTab",
                  "type":"string",
                  "value":"https:\/\/www.uni-weimar.de\/de\/universitaet\/studium\/elearning-labor\/medienbereichertes-lehren-und-lernen\/ueber-das-netzwerk\/"
                 }],

--- a/map.json
+++ b/map.json
@@ -501,11 +501,6 @@
                  "value":"https:\/\/app.leonardo.ai\/auth\/login"
                 }, 
                 {
-                 "name":"openWebsite",
-                 "type":"string",
-                 "value":"https:\/\/app.leonardo.ai\/auth\/login"
-                }, 
-                {
                  "name":"openWebsiteAllowApi",
                  "type":"string",
                  "value":"true"

--- a/map.json
+++ b/map.json
@@ -678,6 +678,11 @@
          "opacity":1,
          "properties":[
                 {
+                 "name":"openTab",
+                 "type":"string",
+                 "value":"https:\/\/www.uni-weimar.de\/de\/universitaet\/studium\/elearning-labor\/medienbereichertes-lehren-und-lernen\/qualifizierung\/kursangebote\/"
+                }, 
+                {
                  "name":"openWebsite",
                  "type":"string",
                  "value":"https:\/\/www.uni-weimar.de\/de\/universitaet\/studium\/elearning-labor\/medienbereichertes-lehren-und-lernen\/qualifizierung\/kursangebote\/"
@@ -1021,6 +1026,11 @@
          "name":"UrlTools",
          "opacity":1,
          "properties":[
+                {
+                 "name":"openTab",
+                 "type":"string",
+                 "value":"https:\/\/www.uni-weimar.de\/de\/universitaet\/studium\/elearning-labor\/medienbereichertes-lehren-und-lernen\/qualifizierung\/themen-und-tools\/"
+                }, 
                 {
                  "name":"openWebsite",
                  "type":"string",

--- a/map.json
+++ b/map.json
@@ -496,6 +496,11 @@
                  "value":true
                 }, 
                 {
+                 "name":"openTab",
+                 "type":"string",
+                 "value":"https:\/\/app.leonardo.ai\/auth\/login"
+                }, 
+                {
                  "name":"openWebsite",
                  "type":"string",
                  "value":"https:\/\/app.leonardo.ai\/auth\/login"
@@ -3870,7 +3875,7 @@
          "value":"script.js"
         }],
  "renderorder":"right-down",
- "tiledversion":"1.8.4",
+ "tiledversion":"1.10.2",
  "tileheight":32,
  "tilesets":[
         {
@@ -4210,6 +4215,6 @@
         }],
  "tilewidth":32,
  "type":"map",
- "version":"1.8",
+ "version":"1.10",
  "width":150
 }

--- a/map.json
+++ b/map.json
@@ -850,6 +850,11 @@
                  "value":"None"
                 }, 
                 {
+                 "name":"openTab",
+                 "type":"string",
+                 "value":"https:\/\/www.youtube.com\/"
+                }, 
+                {
                  "name":"openWebsite",
                  "type":"string",
                  "value":"https:\/\/youtube.com"

--- a/map.json
+++ b/map.json
@@ -1187,11 +1187,6 @@
                  "name":"openTab",
                  "type":"string",
                  "value":"https:\/\/www.uni-weimar.de\/de\/universitaet\/studium\/elearning-labor\/medienbereichertes-lehren-und-lernen\/qualifizierung\/tutoreneteach\/"
-                }, 
-                {
-                 "name":"openWebsite",
-                 "type":"string",
-                 "value":"https:\/\/www.uni-weimar.de\/de\/universitaet\/studium\/elearning-labor\/medienbereichertes-lehren-und-lernen\/qualifizierung\/tutoreneteach\/"
                 }],
          "type":"tilelayer",
          "visible":true,


### PR DESCRIPTION
all iframes are modified from openWebsite property to openTab property to avoid the issue of CSP (content security policy) restrictions, these restrictions can be handled only by contacting the website developement owner to get access for iframe usage or just open in external tabs.
To handle at website development owner he has to work on server side to comprmise some security issues, so i chose not to compromise the website security and modified code with openTab peoperty.